### PR TITLE
Some improvements

### DIFF
--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -580,6 +580,14 @@ class MintUpgrade():
         self.progress("Disabling screensaver and power management")
         self.disable_pm()
 
+        # temporarily allow libpam to auto-restart without asking the user
+        libpam0g_restart_val = "false"
+        o = subprocess.check_output("sudo debconf-show libpam0g | grep libraries\/restart-without-asking", shell=True)
+        if "true" in o.decode():
+            libpam0g_restart_val = "true"
+
+        os.system('echo "libpam0g libraries/restart-without-asking select true" | sudo debconf-set-selections')
+
         self.progress("Saving /etc/fstab")
         os.system("cp /etc/fstab %s" % BACKUP_FSTAB)
 
@@ -654,6 +662,9 @@ class MintUpgrade():
             self.warn("A package modified /etc/fstab during the upgrade. To ensure a successful boot, the\n"
                       "    upgrader restored your original /etc/fstab and saved the modified file in \n"
                       "    %s.upgraded." % BACKUP_FSTAB)
+
+        # restore libpam0g restart value
+        os.system('echo "libpam0g libraries/restart-without-asking select %s" | sudo debconf-set-selections' % libpam0g_restart_val)
 
         self.progress("The upgrade is finished. Reboot the computer with \"sudo reboot\" when ready.")
 

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -7,6 +7,7 @@ import filecmp
 import platform
 import subprocess
 import tempfile
+import pathlib
 
 from gi.repository import GLib
 
@@ -102,6 +103,30 @@ CRYPTTAB_NAME = 0
 CRYPTTAB_PATH = 1
 CRYPTTAB_PW = 2
 CRYPTTAB_OPTS = 3
+
+# Don't allow any other commands until a 'check' has succeeded.
+CHECK_COMPLETE_PATH = pathlib.Path("/tmp/mintupgrade/check_completed")
+
+def ensure_check_completed():
+    if not CHECK_COMPLETE_PATH.exists():
+        print("Please run 'mintupgrade check' before attempting to execute any other commands.")
+        exit(1)
+
+def set_check_completed():
+    CHECK_COMPLETE_PATH.parent.mkdir(exist_ok=True)
+    CHECK_COMPLETE_PATH.touch()
+
+def rm_check_completed():
+    try:
+        # < python 3.8 doesn't have missing_ok parameter
+        CHECK_COMPLETE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+
+    try:
+        CHECK_COMPLETE_PATH.parent.rmdir()
+    except Exception as e:
+        pass
 
 def commented_out(line):
     return line.strip().startswith("#")
@@ -531,6 +556,8 @@ class MintUpgrade():
         if self.command == "check":
             self.warn("Command '%s' completed successfully" % self.command)
 
+        set_check_completed()
+
     def download(self):
         self.progress("Downloading upgrade packages")
         print("")
@@ -864,16 +891,20 @@ if __name__ == '__main__':
     if command == "restore-sources":
         upgrader.restore_sources()
     elif command == "check":
+        rm_check_completed()
         upgrader.prepare()
         upgrader.check()
         upgrader.restore_sources()
     elif command == "download":
+        ensure_check_completed()
         upgrader.prepare()
         upgrader.download()
         upgrader.restore_sources()
     elif command == "upgrade":
+        ensure_check_completed()
         upgrader.prepare()
         upgrader.download()
         upgrader.upgrade()
+        rm_check_completed()
     else:
         usage()

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -787,7 +787,7 @@ class MintUpgrade():
                 problem_messages[make_fs_id(dir)] = "You need %s on '%s' but only have %s. You must free an additional %s." \
                     % (free_needed_str, make_fs_id(dir), initial_free_str, free_at_least_str)
             else:
-                ok_messages[make_fs_id(dir)] = "You need %s on '%s', and have %s free - looks good." \
+                ok_messages[make_fs_id(dir)] = "You need %s on '%s' for the upgrade process, and have %s free - looks good." \
                     % (free_needed_str, make_fs_id(dir), initial_free_str)
 
         if len(ok_messages) > 0:

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -128,6 +128,16 @@ def rm_check_completed():
     except Exception as e:
         pass
 
+def timeshift_config_exists():
+    # Config file location has changed in timeshift 20.11.1 (mint 20 series):
+    # https://github.com/teejee2008/timeshift/commit/55870b94d1402d2d2be71a2170d0ddb036f8f65a
+    # Timeshift moves the file, not copies, so should be in one place OR the other.
+
+    old_path = pathlib.Path("/etc/timeshift.json")
+    new_path = pathlib.Path("/etc/timeshift/timeshift.json")
+
+    return new_path.exists() or old_path.exists()
+
 def commented_out(line):
     return line.strip().startswith("#")
 
@@ -325,7 +335,7 @@ class MintUpgrade():
 
         # Check for timeshift configuration
         self.progress("Checking your Timeshift configuration")
-        if not os.path.exists("/etc/timeshift.json"):
+        if not timeshift_config_exists():
             self.fail("Please set up system snapshots. If anything goes wrong with the upgrade, snapshots will allow you to restore your operating system. Install and configure Timeshift, and create a snapshot before proceeding with the upgrade.")
 
         self.progress("Updating cache")

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -348,7 +348,7 @@ class MintUpgrade():
             # offer to fix?
             self.fail("You have broken packages - please run 'apt install -f' to resolve any issues and try to upgrade again.")
 
-        self.progress("Running autoclean to remove unused packages")
+        self.progress("Running autoremove to remove unused packages")
         self.check_command("sudo apt-get --purge autoremove --yes -o APT::AutoRemove::SuggestsImportant=false", "Failed to autoremove unused packages.")
 
         # Check APT sources (no 3rd party repositories)
@@ -630,7 +630,7 @@ class MintUpgrade():
         for removal in PACKAGES_REMOVALS:
             os.system('sudo apt-get purge --yes %s' % removal) # The return code indicates a failure if some packages were not found, so ignore it.
 
-        self.progress("Running autoclean to remove unused packages")
+        self.progress("Running autoremove to remove unused packages")
         self.check_command("sudo apt-get --purge autoremove --yes -o APT::AutoRemove::SuggestsImportant=false", "Failed to autoremove unused packages.")
 
         self.progress("Performing system adjustments")

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -1,11 +1,14 @@
 #!/usr/bin/python3
 
 import sys, os, apt
+import apt_pkg
 import subprocess
 import filecmp
 import platform
 import subprocess
 import tempfile
+
+from gi.repository import GLib
 
 ORIGIN = "Linux Mint 19.3 'Tricia'"
 ORIGIN_CODENAME = "tricia"
@@ -518,6 +521,10 @@ class MintUpgrade():
                       "    This might or might not indicate a problem. Check the APT output above to decide\n"
                       "    whether to continue with the upgrade. If this OK you might need to update them\n"
                       "    manually after the upgrade." % ", ".join(sorted(kept_packages)))
+
+        self.progress("Checking disk space requirements")
+        self.check_disk_space_requirements(cache)
+
         if self.command == "check":
             self.warn("Command '%s' completed successfully" % self.command)
 
@@ -636,6 +643,120 @@ class MintUpgrade():
             messages.append("Could not inhibit session.  You should disable power management for the duration")
             messages.append("    of this upgrade, and refrain from logging out or switching users.")
             self.continue_yes_no(messages, False)
+
+    def check_disk_space_requirements(self, cache):
+        download_size = 0.0
+        additional_space_needed = 0.0
+
+        # get download size
+        pm = apt_pkg.PackageManager(cache._depcache)
+        fetcher = apt_pkg.Acquire()
+
+        # this may fail, but you'll still get the download size, vs cache.required_download
+        try:
+            pm.get_archives(fetcher, cache._list, cache._records)
+        except:
+            pass
+
+        download_size = fetcher.fetch_needed
+
+        # additional space needed when all finished
+        additional_space_needed = cache._depcache.usr_size
+
+        # gather mount info so we calculate free space correctly.
+        mounted = []
+        mnt_map = {}
+        fs_free = {}
+        with open("/proc/mounts") as mounts:
+            for line in mounts:
+                try:
+                    (what, where, fs, options, a, b) = line.split()
+                except ValueError as e:
+                    # print("line '%s' in /proc/mounts not understood (%s)" % (line, e))
+                    continue
+                if not where in mounted:
+                    mounted.append(where)
+        # make sure mounted is sorted by longest path
+        mounted.sort(key=len, reverse=True)
+
+        class FreeSpace(object):
+            " helper class that represents the free space on each mounted fs "
+            def __init__(self, initialFree):
+                self.initial_free = initialFree
+                self.free = initialFree
+                self.need = 0
+
+        def make_fs_id(d):
+            """ return 'id' of a directory so that directories on the
+                same filesystem get the same id (simply the mount_point)
+            """
+            for mount_point in mounted:
+                if d.startswith(mount_point):
+                    return mount_point
+            return "/"
+
+        archivedir = apt_pkg.config.find_dir("Dir::Cache::archives")
+
+        for d in ["/", "/usr", "/boot", archivedir, "/tmp/"]:
+            d = os.path.realpath(d)
+            fs_id = make_fs_id(d)
+            if os.path.exists(d):
+                st = os.statvfs(d)
+                free = st.f_bavail * st.f_frsize
+            else:
+                # print("directory '%s' does not exists" % d)
+                free = 0
+            if fs_id in mnt_map:
+                # print("Dir %s mounted on %s" % (d, mnt_map[fs_id]))
+                fs_free[d] = fs_free[mnt_map[fs_id]]
+            else:
+                # print("Free space on %s: %s" % (d, free))
+                mnt_map[fs_id] = d
+                fs_free[d] = FreeSpace(free)
+
+        # sum up space requirements
+        for (dir, size) in [
+            (archivedir, download_size),
+            ("/usr", additional_space_needed),
+            # plus 50M safety buffer in /usr
+            ("/usr", 50 * 1024 * 1024), # buffer
+            ("/boot", 50 * 1024 * 1024), # buffer - should we calculate real kernel/initramfs space required?
+            ("/tmp", 5 * 1024 * 1024),   # /tmp for dkms LP: #427035
+            ("/", 10 * 1024 * 1024),     # more buffer /
+        ]:
+            # we are ensuring we have more than enough free space not less
+            if size < 0:
+                continue
+            dir = os.path.realpath(dir)
+            # print("dir '%s' needs '%s' of '%s' (%f)" % (dir, size, fs_free[dir], fs_free[dir].free))
+            fs_free[dir].free -= size
+            fs_free[dir].need += size
+
+        # check for space required violations
+        insufficient = False
+
+        ok_messages = {}
+        problem_messages = {}
+        for dir in fs_free:
+            free_needed_str = GLib.format_size(fs_free[dir].need)
+            initial_free_str = GLib.format_size(fs_free[dir].initial_free)
+
+            if fs_free[dir].free < 0:
+                free_at_least_str = GLib.format_size(abs(fs_free[dir].free) + 1024 * 1024 * 10)
+
+                problem_messages[make_fs_id(dir)] = "You need %s on '%s' but only have %s. You must free an additional %s." \
+                    % (free_needed_str, make_fs_id(dir), initial_free_str, free_at_least_str)
+            else:
+                ok_messages[make_fs_id(dir)] = "You need %s on '%s', and have %s free - looks good." \
+                    % (free_needed_str, make_fs_id(dir), initial_free_str)
+
+        if len(ok_messages) > 0:
+            for msg in list(ok_messages.values()):
+                self.progress(msg)
+
+        if len(problem_messages) > 0:
+            self.critical_warn(list(problem_messages.values()))
+            self.fail("Please free up the required disk space and try again.")
 
     def check_command(self, command, message):
         ret = os.system(command)

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -305,6 +305,11 @@ class MintUpgrade():
         os.system("DEBIAN_PRIORITY=critical sudo apt-get update")
         cache = apt.Cache()
 
+        self.progress("Checking for broken packages")
+        if cache.broken_count > 0:
+            # offer to fix?
+            self.fail("You have broken packages - please run 'apt install -f' to resolve any issues and try to upgrade again.")
+
         # Check APT sources (no 3rd party repositories)
         self.progress("Checking your APT repositories")
         third_party_repositories = get_third_party_repositories()

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -313,6 +313,9 @@ class MintUpgrade():
             # offer to fix?
             self.fail("You have broken packages - please run 'apt install -f' to resolve any issues and try to upgrade again.")
 
+        self.progress("Running autoclean to remove unused packages")
+        self.check_command("sudo apt-get --purge autoremove --yes -o APT::AutoRemove::SuggestsImportant=false", "Failed to autoremove unused packages.")
+
         # Check APT sources (no 3rd party repositories)
         self.progress("Checking your APT repositories")
         third_party_repositories = get_third_party_repositories()
@@ -591,7 +594,7 @@ class MintUpgrade():
             os.system('sudo apt-get purge --yes %s' % removal) # The return code indicates a failure if some packages were not found, so ignore it.
 
         self.progress("Running autoclean to remove unused packages")
-        self.check_command("sudo apt-get --purge autoremove --yes", "Failed to autoremove unused packages.")
+        self.check_command("sudo apt-get --purge autoremove --yes -o APT::AutoRemove::SuggestsImportant=false", "Failed to autoremove unused packages.")
 
         self.progress("Performing system adjustments")
         os.system("sudo rm -f /etc/systemd/logind.conf")

--- a/usr/bin/mintupgrade
+++ b/usr/bin/mintupgrade
@@ -526,18 +526,7 @@ class MintUpgrade():
 
     def upgrade(self):
         self.progress("Disabling screensaver and power management")
-        os.system("killall cinnamon-screensaver")
-        os.system("killall mate-screensaver")
-        os.system("killall light-locker")
-
-        current_desktop = os.getenv("XDG_CURRENT_DESKTOP")
-        if current_desktop != None:
-            current_desktop = current_desktop.lower().replace("x-", "") # X-Cinnamon
-            if current_desktop == "xfce":
-                self.warn("Could not inhibit session.  You should disable power management for the duration\n"
-                          "    of this upgrade, and refrain from logging out or switching users.")
-            else:
-                subprocess.Popen(["mintupgrade-inhibit-power", str(os.getpid())])
+        self.disable_pm()
 
         self.progress("Saving /etc/fstab")
         os.system("cp /etc/fstab %s" % BACKUP_FSTAB)
@@ -615,6 +604,33 @@ class MintUpgrade():
                       "    %s.upgraded." % BACKUP_FSTAB)
 
         self.progress("The upgrade is finished. Reboot the computer with \"sudo reboot\" when ready.")
+
+    def disable_pm(self):
+        os.system("killall cinnamon-screensaver")
+        os.system("killall mate-screensaver")
+        os.system("killall light-locker")
+
+        inhibit_failed = False
+
+        current_desktop = os.getenv("XDG_CURRENT_DESKTOP")
+        if current_desktop != None:
+            current_desktop = current_desktop.lower().replace("x-", "") # X-Cinnamon
+            p = subprocess.Popen(["mintupgrade-inhibit-power", str(os.getpid()), current_desktop])
+
+            try:
+                # process should wait until we exit. If it exits early, it failed.
+                p.wait(3)
+                inhibit_failed = True
+            except:
+                pass
+        else:
+            inhibit_failed = True
+
+        if inhibit_failed:
+            messages = []
+            messages.append("Could not inhibit session.  You should disable power management for the duration")
+            messages.append("    of this upgrade, and refrain from logging out or switching users.")
+            self.continue_yes_no(messages, False)
 
     def check_command(self, command, message):
         ret = os.system(command)

--- a/usr/bin/mintupgrade-inhibit-power
+++ b/usr/bin/mintupgrade-inhibit-power
@@ -5,6 +5,7 @@ import time
 
 from gi.repository import GLib, Gio
 
+desktop = sys.argv[2]
 bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
     # 1: Inhibit logging out
@@ -14,21 +15,30 @@ bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
 FLAGS = 1 | 2 | 4 | 8
 
-# This doesn't work on xfce.  Their session manager doesn't
-# appear to support Inhibit.
+if desktop == "xfce":
+    name = "org.freedesktop.PowerManagement"
+    path = "/org/freedesktop/PowerManagement/Inhibit"
+    iface = "org.freedesktop.PowerManagement.Inhibit"
+    args = GLib.Variant("(ss)", ("mintupgrade", "Performing a system upgrade"))
+else:
+    name = "org.gnome.SessionManager"
+    path = "/org/gnome/SessionManager"
+    iface = "org.gnome.SessionManager"
+    args = GLib.Variant("(susu)", ("mintupgrade", 0, "Performing a system upgrade", FLAGS))
+
 try:
-    bus.call_sync("org.gnome.SessionManager",
-                  "/org/gnome/SessionManager",
-                  "org.gnome.SessionManager",
+    bus.call_sync(name,
+                  path,
+                  iface,
                   "Inhibit",
-                  GLib.Variant("(susu)",
-                               ("mintupgrade", 0, "Performing a system upgrade", FLAGS)),
+                  args,
                   None,
                   Gio.DBusCallFlags.NONE,
                   2000,
                   None)
-except:
-    pass
+except Exception as e:
+    exit(1)
+    # print(e)
 
 while psutil.pid_exists(int(sys.argv[1])):
     time.sleep(1)


### PR DESCRIPTION
See individual commit messages.

Other things:
Should we run 'upgrade' with sudo?  Will prevent having to re-enter password repeatedly.

If check, download or upgrade fail in the wrong place (crash), they'll end up with the wrong sources. If the user re-tries the step, they'll get false reports of wrong-version packages.

Perhaps offer to restore sources if backups are detected, or ask if the program ended abnormally and suggest it then.

Or,
Touch some temp file at the start of the process. Any time we exit in a controlled fashion, we remove the file.  If the file exists when they run mintupgrade again, we can know there was a problem, and maybe perform some diagnostic or at least ensure they're in a usable state.